### PR TITLE
[chore][db] Skip already processed images during folder scan by query…

### DIFF
--- a/db.py
+++ b/db.py
@@ -79,6 +79,20 @@ class Database:
 
         return [row[0] for row in rows]
 
+    def get_processed_images(self):
+        """
+        Return a set of image paths already indexed in occurrences.
+        """
+        query = """
+                SELECT DISTINCT images.path
+                FROM occurrences
+                JOIN images ON occurrences.image_id = images.id
+        """
+
+        with self.lock:
+            c = self.conn.cursor()
+            c.execute(query)
+        return {row[0] for row in c.fetchall()}
 
     def get_face_thumbnail(self, face_id):
         thumb_dir = 'resources/thumbnails'


### PR DESCRIPTION
This pull request introduces enhancements to the folder scanning and image filtering logic in `controller.py` and adds a new database query method in `db.py`. The changes aim to improve efficiency by avoiding reprocessing already indexed images.

### Enhancements to folder scanning and filtering:
* [`controller.py`](diffhunk://#diff-00066c2c6a38edb38037523eac2c0f6f4e2c7801786b691402bb684046b81956L33-R47): Updated the `scan_folder` method to filter out already processed images by comparing the scanned image paths with a list retrieved from the database. Introduced a new variable `new_images` to hold only unprocessed images, ensuring that the `image_queue` contains these images for further processing. Updated logging to include counts of total and new images.

### Database query improvements:
* [`db.py`](diffhunk://#diff-e38886c9c347274d45df17345018e0c7415786cb04a398d881a41bc5ec8d651bR82-R95): Added a new method `get_processed_images` to retrieve a set of image paths already indexed in the database by querying the `occurrences` and `images` tables. This method ensures efficient filtering of processed images during folder scanning.